### PR TITLE
Fix removeFromRooms firebase function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -37,7 +37,7 @@ exports.removeFromRooms = userOnlineRef.onUpdate((change, context) => {
     .then((userState) => {
       if (!userState) {
         return admin.database()
-          .ref(`users/${userId}/online`)
+          .ref(`users/${userId}/activeRoom`)
           .once('value')
           .then(activeSnap => activeSnap && activeSnap.val())
           .then((activeRoom) => {


### PR DESCRIPTION
# Description

After the latest fix, with automatic release and deployment working, I've notice that the `removeFromRooms` suddenly stopped working.

After some investigation I realised that the path used in order to "remove" an offline from rooms were wrong, and because of that we had a lot of false information regarding user presence at rooms =(