### PR TITLE
Adiciona password no Jitsi para melhorar seguraça

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -22,6 +22,10 @@
     "blockedUsers": {
       ".read": false,
       ".write": false
+    },
+    "config": {
+      ".read": "auth.uid != null && auth.uid != null && root.child('blockedUsers').child(auth.uid).val() != true",
+      ".write": false
     }
   }
 }

--- a/src/components/Meet.svelte
+++ b/src/components/Meet.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte'
   import { getUserProfile } from '../services/local'
-  import { Rooms } from '../models'
+  import { Rooms, Config } from '../models'
   import { appSlug } from '../../config'
 
   export let activeRoom
@@ -11,6 +11,8 @@
 
   onMount(async () => {
     const room = await Rooms.get(`${activeRoom}`)
+    const { jitsiPassword } = await Config.get(`/`)
+
     if (room.noJitsi) {
       noJitsi = true
       return
@@ -61,7 +63,9 @@
       meet._frame.style.height = 'calc(100vh - 170px)'
       meet.executeCommand('displayName', userProfile.name)
       meet.executeCommand('avatarUrl', userProfile.picture)
-    }, 1000)
+      meet.on('participantRoleChanged', () => meet.executeCommand('password', jitsiPassword))
+      meet.on('passwordRequired', () => meet.executeCommand('password', jitsiPassword))
+    }, 500)
   })
 </script>
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -4,3 +4,4 @@ import UsersModel from './users'
 export const Root = new BaseModel('/')
 export const Users = new UsersModel()
 export const Rooms = new BaseModel('rooms')
+export const Config = new BaseModel('config')


### PR DESCRIPTION
# Descrição

Esse PR tem como objetivo proteger nosso componente de vídeo com um password geral da nossa conta.
Essa senha é usada sempre que entramos em uma sala.