### PR TITLE
fix(Room): add z-index to exit button

### DIFF
--- a/src/components/UserProfile.svelte
+++ b/src/components/UserProfile.svelte
@@ -41,7 +41,7 @@
     border-radius: 6px;
     padding: 5px 0;
     position: absolute;
-    z-index: 1;
+    z-index: 2;
     margin-top: -135px;
     margin-left: -5px;
     padding: 3px;

--- a/src/components/UserProfile.svelte
+++ b/src/components/UserProfile.svelte
@@ -27,6 +27,7 @@
     height: 200%;
     width: 200%;
     z-index: 1;
+    pointer-events: none;
   }
 
   div {


### PR DESCRIPTION
## Description
- Adicionando `pointer-events: none` para que o tamanho da div não afete o botão de sair.
- Balão com nome de usuário ao passar o mouse em cima fica abaixo da imagem do chapéu.

![print](https://user-images.githubusercontent.com/4103305/110635923-6aab1900-818a-11eb-8bf1-e3c813af5718.png)

![print2](https://user-images.githubusercontent.com/4103305/110637481-30db1200-818c-11eb-827a-5669428cdcb5.png)

