### PR TITLE
UserProfile: fix tooltip position

### DIFF
--- a/src/components/UserProfile.svelte
+++ b/src/components/UserProfile.svelte
@@ -42,9 +42,9 @@
     padding: 5px 0;
     position: absolute;
     z-index: 2;
-    margin-top: -135px;
-    margin-left: -5px;
     padding: 3px;
+    bottom: 0;
+    left: 10px;
   }
 
   div:hover .tooltiptext {


### PR DESCRIPTION
## Description
Alterando código de posicionamento da tooltip. Dependendo da extensão do nome ficava muito abaixo.

### Antes
![modify_1](https://user-images.githubusercontent.com/4103305/110995934-e7d8b880-8359-11eb-92c0-24a12905d76b.png)

### Depois
![modify_2](https://user-images.githubusercontent.com/4103305/110995944-e9a27c00-8359-11eb-979b-0028e07fbb76.png)
