### PR TITLE
Fix video room setup

### DIFF
--- a/src/components/Meet.svelte
+++ b/src/components/Meet.svelte
@@ -62,8 +62,10 @@
     setTimeout(() => {
       const meet = new JitsiMeetExternalAPI(domain, options)
       meet._frame.style.height = 'calc(100vh - 170px)'
-      meet.executeCommand('displayName', userProfile.name)
-      meet.executeCommand('avatarUrl', userProfile.picture)
+      meet.on('videoConferenceJoined', () => {
+        meet.executeCommand('displayName', userProfile.name)
+        meet.executeCommand('avatarUrl', userProfile.picture)
+      })
       meet.on('participantRoleChanged', () => meet.executeCommand('password', jitsiPassword))
       meet.on('passwordRequired', () => meet.executeCommand('password', jitsiPassword))
     }, 500)


### PR DESCRIPTION
# Description

This PR fix whenever a user join a meet and receive a weird console.error message about `jq...` because the iframe is not yet mounted